### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - node
   - 10
 script:
   - npm run build

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "npm run serve",
     "serve": "node dist/server.js",
     "serve-debug": "node --inspect dist/server.js",
-    "test": "jest --coverage --verbose",
+    "test": "jest --coverage --verbose --forceExit",
     "build": "npm run build-ts && npm run tslint && npm run copy-static-assets",
     "build-ts": "tsc",
     "tslint": "tslint -c tslint.json -p tsconfig.json",


### PR DESCRIPTION
I had a misunderstanding regarding how to provide the Node.js version to use in Travis CI.

Furthermore I have a test which actually initiates a real site check (which is bad...), which caused Travis CI to complain about the fact that "Jest did not exit one second after the test run has completed". For the time being I avoid this issue with Jest's `--forceExit` option, but I really need to further refactor my Scanner module instead so I can test with a mock rather than initiating a real site check.